### PR TITLE
Include Fetch & Crypto modules

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -60,7 +60,7 @@ dependencies = [
  "regex",
  "rustc-hash",
  "shlex",
- "syn 2.0.96",
+ "syn 2.0.98",
  "which",
 ]
 
@@ -81,15 +81,21 @@ dependencies = [
 
 [[package]]
 name = "bumpalo"
-version = "3.16.0"
+version = "3.17.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "79296716171880943b8470b5f8d03aa55eb2e645a4874bdbb28adb49162e012c"
+checksum = "1628fb46dfa0b37568d12e5edd512553eccf6a22a78e8bde00bb4aed84d5bdbf"
+
+[[package]]
+name = "byteorder"
+version = "1.5.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1fd0f2584146f6f2ef48085050886acf353beff7305ebd1ae69500e27c67f64b"
 
 [[package]]
 name = "cc"
-version = "1.2.10"
+version = "1.2.12"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "13208fcbb66eaeffe09b99fffbe1af420f00a7b35aa99ad683dfc1aa76145229"
+checksum = "755717a7de9ec452bf7f3f1a3099085deabd7f2962b861dae91ecd7a365903d2"
 dependencies = [
  "shlex",
 ]
@@ -293,6 +299,9 @@ dependencies = [
  "anyhow",
  "blockless-sdk",
  "javy-plugin-api",
+ "rand",
+ "serde",
+ "serde_json",
 ]
 
 [[package]]
@@ -399,13 +408,22 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "1261fe7e33c73b354eab43b1273a57c8f967d0391e80353e51f764ac02cf6775"
 
 [[package]]
+name = "ppv-lite86"
+version = "0.2.20"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "77957b295656769bb8ad2b6a6b09d897d94f05c41b069aede1fcdaa675eaea04"
+dependencies = [
+ "zerocopy",
+]
+
+[[package]]
 name = "prettyplease"
 version = "0.2.29"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "6924ced06e1f7dfe3fa48d57b9f74f55d8915f5036121bef647ef4b204895fac"
 dependencies = [
  "proc-macro2",
- "syn 2.0.96",
+ "syn 2.0.98",
 ]
 
 [[package]]
@@ -477,6 +495,18 @@ version = "0.8.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "34af8d1a0e25924bc5b7c43c079c942339d8f0a8b57c39049bef581b46327404"
 dependencies = [
+ "libc",
+ "rand_chacha",
+ "rand_core",
+]
+
+[[package]]
+name = "rand_chacha"
+version = "0.3.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e6c10a63a0fa32252be49d21e7709d4d4baf8d231c2dbce1eaa8141b9b127d88"
+dependencies = [
+ "ppv-lite86",
  "rand_core",
 ]
 
@@ -506,7 +536,7 @@ checksum = "bcc303e793d3734489387d205e9b186fac9c6cfacedd98cbb2e8a5943595f3e6"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.96",
+ "syn 2.0.98",
 ]
 
 [[package]]
@@ -579,7 +609,7 @@ dependencies = [
  "proc-macro2",
  "quote",
  "rquickjs-core",
- "syn 2.0.96",
+ "syn 2.0.98",
 ]
 
 [[package]]
@@ -643,14 +673,14 @@ checksum = "5a9bf7cf98d04a2b28aead066b7496853d4779c9cc183c440dbac457641e19a0"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.96",
+ "syn 2.0.98",
 ]
 
 [[package]]
 name = "serde_json"
-version = "1.0.137"
+version = "1.0.138"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "930cfb6e6abf99298aaad7d29abbef7a9999a9a8806a40088f55f0dcec03146b"
+checksum = "d434192e7da787e94a6ea7e9670b26a036d0ca41e0b7efb2676dd32bae872949"
 dependencies = [
  "itoa",
  "memchr",
@@ -697,9 +727,9 @@ dependencies = [
 
 [[package]]
 name = "syn"
-version = "2.0.96"
+version = "2.0.98"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d5d0adab1ae378d7f53bdebc67a39f1f151407ef230f0ce2883572f5d8985c80"
+checksum = "36147f1a48ae0ec2b5b3bc5b537d267457555a10dc06f3dbc8cb11ba3006d3b1"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -780,7 +810,7 @@ dependencies = [
  "log",
  "proc-macro2",
  "quote",
- "syn 2.0.96",
+ "syn 2.0.98",
  "wasm-bindgen-shared",
 ]
 
@@ -802,7 +832,7 @@ checksum = "8ae87ea40c9f689fc23f209965b6fb8a99ad69aeeb0231408be24920604395de"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.96",
+ "syn 2.0.98",
  "wasm-bindgen-backend",
  "wasm-bindgen-shared",
 ]
@@ -916,6 +946,7 @@ version = "0.7.35"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "1b9b4fd18abc82b8136838da5d50bae7bdea537c574d8dc1a34ed098d6c166f0"
 dependencies = [
+ "byteorder",
  "zerocopy-derive",
 ]
 
@@ -927,5 +958,5 @@ checksum = "fa4f8080344d4671fb4e831a13ad1e68092748387dfc4f55e356242fae12ce3e"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.96",
+ "syn 2.0.98",
 ]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -24,3 +24,9 @@ serde = { version = "1.0.215", features = ["derive"] }
 [profile.release]
 lto = true
 opt-level = 3
+
+[features]
+crypto = []
+fetch = []
+llm = []
+default = ["crypto", "fetch"]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -17,6 +17,9 @@ crate-type = ["cdylib"]
 anyhow = "1.0.95"
 blockless-sdk = { version = "0.1.6" }
 javy-plugin-api = { version = "3.0.0", features = ["json"] }
+rand = "0.8.5"
+serde_json = "1.0.120"
+serde = { version = "1.0.215", features = ["derive"] }
 
 [profile.release]
 lto = true

--- a/Makefile
+++ b/Makefile
@@ -1,0 +1,79 @@
+# Variables
+TARGET = wasm32-wasip1
+RELEASE_TARGET = ./target/$(TARGET)/release/bless_plugins.wasm
+DEBUG_TARGET = ./target/$(TARGET)/debug/bless_plugins.wasm
+FINAL_WASM = bless_plugins.wasm
+
+# Default target
+.PHONY: all
+all: build
+
+# Build release version
+.PHONY: build
+build: $(FINAL_WASM)
+
+$(FINAL_WASM): $(RELEASE_TARGET)
+	./javy init-plugin $< -o $@
+
+$(RELEASE_TARGET):
+	cargo build --target=$(TARGET) --release
+
+# Build debug version
+.PHONY: debug
+debug: $(DEBUG_TARGET)
+	javy init-plugin $< -o debug_$(FINAL_WASM)
+
+$(DEBUG_TARGET):
+	cargo build --target=$(TARGET)
+
+# Check code without building
+.PHONY: check
+check:
+	cargo check --target=$(TARGET)
+
+# Run tests
+.PHONY: test
+test:
+	cargo test
+
+# Format code
+.PHONY: fmt
+fmt:
+	cargo fmt
+
+# Check formatting
+.PHONY: fmt-check
+fmt-check:
+	cargo fmt -- --check
+
+# Run clippy lints
+.PHONY: lint
+lint:
+	cargo clippy --target=$(TARGET) -- -D warnings
+
+# Clean build artifacts
+.PHONY: clean
+clean:
+	cargo clean
+	rm -f $(FINAL_WASM)
+	rm -f debug_$(FINAL_WASM)
+
+# Install required tools
+.PHONY: install-tools
+install-tools:
+	rustup target add $(TARGET)
+	@echo "Please install javy-cli manually from: https://github.com/bytecodealliance/javy"
+
+# Help target
+.PHONY: help
+help:
+	@echo "Available targets:"
+	@echo "  build        - Build release version (default)"
+	@echo "  debug        - Build debug version"
+	@echo "  check       - Check code without building"
+	@echo "  test        - Run tests"
+	@echo "  fmt         - Format code"
+	@echo "  fmt-check   - Check code formatting"
+	@echo "  lint        - Run clippy lints"
+	@echo "  clean       - Clean build artifacts"
+	@echo "  install-tools - Install required tools (except javy-cli)" 

--- a/README.md
+++ b/README.md
@@ -7,6 +7,8 @@ These are the plugins for the [Javy](https://github.com/blessnetwork/bls-javy) r
 | Plugin | Description | [Browser Runtime](https://github.com/blocklessnetwork/b7s-browser) supported | [Native Runtime]([https://github.com/blessnetwork/bls-runtime) supported |
 |--------|-------------|--------------------------|--------------------------|
 | `BlessLLM` | A plugin for interacting with LLMs | ✅ | ❌ |
+| `BlessFetch` | A plugin for interacting with HTTP / fetch | ✅ | ✅ |
+| `BlessCrypto` | A plugin for interacting with the crypto library | ✅ | ✅ |
 
 ## Pre-Requisites
 

--- a/src/crypto/crypto.js
+++ b/src/crypto/crypto.js
@@ -1,0 +1,17 @@
+// Wrap everything in an anonymous function to avoid leaking local variables into the global scope.
+(function () {
+    // Get a reference to the function before we delete it from `globalThis`.
+    const __javy_crypto_get_random_values = globalThis.__javy_crypto_get_random_values;
+
+    function getRandomValues(data) {
+        __javy_crypto_get_random_values(data.buffer, data.byteOffset, data.byteLength)
+        return new Uint8Array(data.buffer)
+    }
+
+    globalThis.crypto = {
+        getRandomValues
+    }
+
+    // Delete the function from `globalThis` so it doesn't leak.
+    Reflect.deleteProperty(globalThis, "__javy_crypto_get_random_values");
+})();

--- a/src/crypto/mod.rs
+++ b/src/crypto/mod.rs
@@ -1,0 +1,55 @@
+use anyhow::{anyhow, bail, Error, Result};
+use javy_plugin_api::javy::{
+    quickjs::{qjs::JS_GetArrayBuffer, Value},
+    Args,
+};
+use rand::RngCore;
+
+pub fn bless_get_random_values(args: Args<'_>) -> Result<Value<'_>> {
+    let (cx, args) = args.release();
+    let (data, offset, length) = extract_args(&args, "Javy.Crypto.getRandomValues")?;
+
+    let offset = offset
+        .as_number()
+        .ok_or_else(|| anyhow!("offset must be a number"))? as usize;
+    let length = length
+        .as_number()
+        .ok_or_else(|| anyhow!("length must be a number"))? as usize;
+
+    // Safety: Port of previous implementation
+    let data = unsafe {
+        let mut len = 0;
+        let ptr = JS_GetArrayBuffer(cx.as_raw().as_ptr(), &mut len, data.as_raw());
+        if ptr.is_null() {
+            bail!("Data must be an ArrayBuffer");
+        }
+
+        Ok::<_, Error>(std::slice::from_raw_parts_mut(ptr, len as _))
+    }?;
+
+    let data = &mut data[offset..(offset + length)];
+
+    // Fill the buffer with random values
+    rand::rngs::OsRng.fill_bytes(data);
+
+    Ok(Value::new_undefined(cx.clone()))
+}
+
+fn extract_args<'a, 'js: 'a>(
+    args: &'a [Value<'js>],
+    for_func: &str,
+) -> Result<(&'a Value<'js>, &'a Value<'js>, &'a Value<'js>)> {
+    let [data, offset, length, ..] = args else {
+        bail!(
+            r#"{} expects 3 parameters: the file descriptor, the
+           TypedArray buffer, the TypedArray byteOffset and the TypedArray
+           byteLength.
+
+           Got: {} parameters."#,
+            for_func,
+            args.len()
+        );
+    };
+
+    Ok((data, offset, length))
+}

--- a/src/fetch/blockless.rs
+++ b/src/fetch/blockless.rs
@@ -1,0 +1,229 @@
+use std::cmp::Ordering;
+use serde_json::{json, Value};
+use crate::fetch::FetchOptions;
+
+pub type Handle = u32;
+
+pub type CodeStatus = u32;
+
+pub struct BlocklessHttp {
+    inner: Handle,
+    code: CodeStatus,
+}
+
+pub struct HttpOptions {
+    method: String,
+    connect_timeout: u32,
+    read_timeout: u32,
+    body: Option<String>,
+}
+
+impl HttpOptions {
+    pub fn new(method: &str, connect_timeout: u32, read_timeout: u32) -> Self {
+        HttpOptions {
+            method: method.into(),
+            connect_timeout,
+            read_timeout,
+            body: None,
+        }
+    }
+
+    pub fn to_json(&self) -> Value {
+        json!({
+            "method": self.method,
+            "connectTimeout": self.connect_timeout,
+            "readTimeout": self.read_timeout,
+            "headers": "{}",
+            "body": self.body,
+        })
+    }
+}
+
+impl BlocklessHttp {
+    pub fn open(url: &str, opts: &FetchOptions) -> Result<Self, HttpErrorKind> {
+        let http_opts = HttpOptions::new(&opts.method, 30, 10);
+        let http_opts_str = serde_json::to_string(&http_opts.to_json()).unwrap();
+
+        let mut fd = 0;
+        let mut status = 0;
+        let rs = unsafe {
+            http_open(
+                url.as_ptr(),
+                url.len() as _,
+                http_opts_str.as_ptr(),
+                http_opts_str.len() as _,
+                &mut fd,
+                &mut status,
+            )
+        };
+        if rs != 0 {
+            return Err(HttpErrorKind::from(rs));
+        }
+        Ok(Self {
+            inner: fd,
+            code: status,
+        })
+    }
+
+    pub fn get_code(&self) -> CodeStatus {
+        self.code
+    }
+
+    pub fn get_all_body(&self) -> Result<Vec<u8>, HttpErrorKind> {
+        let mut vec = Vec::new();
+        loop {
+            let mut buf = [0u8; 1024];
+            let mut num: u32 = 0;
+            let rs =
+                unsafe { http_read_body(self.inner, buf.as_mut_ptr(), buf.len() as _, &mut num) };
+
+            if rs == u32::MAX {
+                continue;
+            } else if rs != 0 {
+                return Err(HttpErrorKind::from(rs));
+            } else {
+                match num.cmp(&0) {
+                    Ordering::Greater => vec.extend_from_slice(&buf[0..num as _]),
+                    _ => break,
+                }
+            }
+        }
+        Ok(vec)
+    }
+
+    pub fn get_header(&self, header: &str) -> Result<String, HttpErrorKind> {
+        let mut vec = Vec::new();
+        loop {
+            let mut buf = [0u8; 1024];
+            let mut num: u32 = 0;
+            let rs = unsafe {
+                http_read_header(
+                    self.inner,
+                    header.as_ptr(),
+                    header.len() as _,
+                    buf.as_mut_ptr(),
+                    buf.len() as _,
+                    &mut num,
+                )
+            };
+
+            if rs == u32::MAX {
+                continue;
+            } else if rs != 0 {
+                return Err(HttpErrorKind::from(rs));
+            } else {
+                match num.cmp(&0) {
+                    Ordering::Greater => vec.extend_from_slice(&buf[0..num as _]),
+                    _ => break,
+                }
+            }
+        }
+        String::from_utf8(vec).map_err(|_| HttpErrorKind::Utf8Error)
+    }
+
+    pub fn close(self) {
+        unsafe {
+            http_close(self.inner);
+        }
+    }
+
+    pub fn read_body(&self, buf: &mut [u8]) -> Result<u32, HttpErrorKind> {
+        let mut num: u32 = 0;
+        let rs = unsafe { http_read_body(self.inner, buf.as_mut_ptr(), buf.len() as _, &mut num) };
+        if rs != 0 {
+            return Err(HttpErrorKind::from(rs));
+        }
+        Ok(num)
+    }
+}
+
+#[derive(Debug)]
+pub enum HttpErrorKind {
+    InvalidDriver,
+    InvalidHandle,
+    MemoryAccessError,
+    BufferTooSmall,
+    HeaderNotFound,
+    Utf8Error,
+    DestinationNotAllowed,
+    InvalidMethod,
+    InvalidEncoding,
+    InvalidUrl,
+    RequestError,
+    RuntimeError,
+    TooManySessions,
+    PermissionDeny,
+}
+
+impl std::error::Error for HttpErrorKind {}
+
+impl std::fmt::Display for HttpErrorKind {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        match *self {
+            Self::InvalidDriver => write!(f, "Invalid Driver"),
+            Self::InvalidHandle => write!(f, "Invalid Error"),
+            Self::MemoryAccessError => write!(f, "Memory Access Error"),
+            Self::BufferTooSmall => write!(f, "Buffer too small"),
+            Self::HeaderNotFound => write!(f, "Header not found"),
+            Self::Utf8Error => write!(f, "Utf8 error"),
+            Self::DestinationNotAllowed => write!(f, "Destination not allowed"),
+            Self::InvalidMethod => write!(f, "Invalid method"),
+            Self::InvalidEncoding => write!(f, "Invalid encoding"),
+            Self::InvalidUrl => write!(f, "Invalid url"),
+            Self::RequestError => write!(f, "Request url"),
+            Self::RuntimeError => write!(f, "Runtime error"),
+            Self::TooManySessions => write!(f, "Too many sessions"),
+            Self::PermissionDeny => write!(f, "Permission deny."),
+        }
+    }
+}
+
+impl From<u32> for HttpErrorKind {
+    fn from(i: u32) -> HttpErrorKind {
+        match i {
+            1 => HttpErrorKind::InvalidHandle,
+            2 => HttpErrorKind::MemoryAccessError,
+            3 => HttpErrorKind::BufferTooSmall,
+            4 => HttpErrorKind::HeaderNotFound,
+            5 => HttpErrorKind::Utf8Error,
+            6 => HttpErrorKind::DestinationNotAllowed,
+            7 => HttpErrorKind::InvalidMethod,
+            8 => HttpErrorKind::InvalidEncoding,
+            9 => HttpErrorKind::InvalidUrl,
+            10 => HttpErrorKind::RequestError,
+            11 => HttpErrorKind::RuntimeError,
+            12 => HttpErrorKind::TooManySessions,
+            13 => HttpErrorKind::PermissionDeny,
+            _ => HttpErrorKind::RuntimeError,
+        }
+    }
+}
+
+#[link(wasm_import_module = "blockless_http")]
+extern "C" {
+    #[link_name = "http_req"]
+    pub(crate) fn http_open(
+        url: *const u8,
+        url_len: u32,
+        opts: *const u8,
+        opts_len: u32,
+        fd: *mut u32,
+        status: *mut u32,
+    ) -> u32;
+
+    #[link_name = "http_read_header"]
+    pub(crate) fn http_read_header(
+        handle: u32,
+        header: *const u8,
+        header_len: u32,
+        buf: *mut u8,
+        buf_len: u32,
+        num: *mut u32,
+    ) -> u32;
+
+    #[link_name = "http_read_body"]
+    pub(crate) fn http_read_body(handle: u32, buf: *mut u8, buf_len: u32, num: *mut u32) -> u32;
+
+    #[link_name = "http_close"]
+    pub(crate) fn http_close(handle: u32) -> u32;
+}

--- a/src/fetch/fetch.js
+++ b/src/fetch/fetch.js
@@ -1,0 +1,36 @@
+// Wrap everything in an anonymous function to avoid leaking local variables into the global scope.
+(function () {
+    // Get a reference to the function before we delete it from `globalThis`.
+    const __javy_fetchio_request = globalThis.__javy_fetchio_request;
+
+    function fetch(url, options = {}) {
+        // const encodedOutput = new TextEncoder().encode(JSON.stringify(options))
+        // const data = new Uint8Array(encodedOutput)
+        const parsedOptions = JSON.stringify(options)
+
+        const responseObj = __javy_fetchio_request(url, parsedOptions);
+
+        // @TODO: Capture all response data from response object
+        const responseOk = responseObj.ok;
+        const responseHeaders = {};
+        const responseBody = responseObj.body;
+
+        return new Promise((resolve, reject) => {
+            const response = {
+                url,
+                headers: responseHeaders,
+                ok: responseOk,
+                type: typeof responseBody === 'string' ? 'text' : 'json',
+                text: () => typeof responseBody === 'string' ? responseBody : JSON.stringify(responseBody),
+                json: () => typeof responseBody !== 'string' ? responseBody : JSON.parse(responseBody),
+            };
+
+            resolve(response);
+        });
+    }
+
+    globalThis.fetch = fetch
+
+    // Delete the function from `globalThis` so it doesn't leak.
+    Reflect.deleteProperty(globalThis, "__javy_fetchio_request");
+})();

--- a/src/fetch/mod.rs
+++ b/src/fetch/mod.rs
@@ -1,0 +1,77 @@
+mod blockless;
+
+use anyhow::{anyhow, bail, Result};
+use blockless::BlocklessHttp;
+use javy_plugin_api::javy::quickjs::{Object as JSObject, String as JSString, Value};
+use javy_plugin_api::javy::Args;
+use serde::{Deserialize, Serialize};
+
+#[derive(Debug, Serialize, Deserialize)]
+pub struct FetchOptions {
+    method: String,
+}
+
+impl FetchOptions {
+    pub fn new(method: &str) -> Self {
+        FetchOptions {
+            method: method.into(),
+        }
+    }
+
+    pub fn to_string(&self) -> String {
+        serde_json::to_string(&self).unwrap()
+    }
+}
+
+pub fn bless_fetch_request(args: Args<'_>) -> Result<Value<'_>> {
+    let (cx, args) = args.release();
+    let (url, options) = extract_http_args(&args, "Javy.Fetch.request")?;
+
+    let url: String = url
+        .as_string()
+        .ok_or_else(|| anyhow!("url must be a string"))?
+        .to_string()
+        .map_err(|_| anyhow!("invalid UTF-8 in url"))?;
+
+    let options: String = options
+        .as_string()
+        .ok_or_else(|| anyhow!("options must be a string"))?
+        .to_string()
+        .map_err(|_| anyhow!("invalid UTF-8 in options"))?;
+
+    let request_obj: FetchOptions = serde_json::from_str(&options)?;
+
+    // Prepare Response
+    // let mut response: HashMap<String, Value<'_>> = HashMap::new();
+    let response_obj = JSObject::new(cx.clone()).unwrap();
+
+    let http = BlocklessHttp::open(&url, &request_obj).unwrap();
+    let body = String::from_utf8(http.get_all_body().unwrap()).unwrap();
+    http.close();
+
+    response_obj.set("ok", Value::new_bool(cx.clone(), true))?;
+    response_obj.set(
+        "body",
+        Value::from_string(JSString::from_str(cx.clone(), &body)?),
+    )?;
+
+    Ok(Value::from_object(response_obj))
+}
+
+fn extract_http_args<'a, 'js: 'a>(
+    args: &'a [Value<'js>],
+    for_func: &str,
+) -> Result<(&'a Value<'js>, &'a Value<'js>)> {
+    let [url, options, ..] = args else {
+        bail!(
+            r#"{} expects 2 parameters: the URL, the TypedArray buffer,
+           the TypedArray byteOffset and the TypedArray byteLength.
+
+           Got: {} parameters."#,
+            for_func,
+            args.len()
+        );
+    };
+
+    Ok((url, options))
+}

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -1,38 +1,75 @@
 //! Javy Bless Plugins
+pub mod crypto;
+pub mod fetch;
+pub mod llm;
 
-use anyhow::{anyhow, Result};
-use blockless_sdk::{BlocklessLlm, LlmOptions};
+use crypto::bless_get_random_values;
+
+use fetch::bless_fetch_request;
 use javy_plugin_api::{
     import_namespace,
     javy::{
         hold, hold_and_release,
-        quickjs::{prelude::MutFn, Function, Object, String as JSString, Value},
+        quickjs::{prelude::MutFn, Function},
         to_js_error, Args,
     },
     Config,
 };
-use std::sync::{Arc, Mutex};
 
-import_namespace!("bless_plugins");
+// use llm::bless_llm_plugin;
+
+import_namespace!("bless_core_plugins");
 
 #[export_name = "initialize_runtime"]
 pub extern "C" fn initialize_runtime() {
-    let config = Config::default();
+    let mut config = Config::default();
+    config.event_loop(true);
+    config.javy_stream_io(true);
+    config.text_encoding(true);
+
     javy_plugin_api::initialize_runtime(config, |runtime| {
         runtime
             .context()
             .with(|ctx| {
                 ctx.globals().set(
-                    "BlessLLM",
+                    "__javy_crypto_get_random_values",
                     Function::new(
                         ctx.clone(),
                         MutFn::new(move |cx, args| {
                             let (cx, args) = hold_and_release!(cx, args);
-                            bless_llm_plugin(hold!(cx.clone(), args))
+                            bless_get_random_values(hold!(cx.clone(), args))
                                 .map_err(|e| to_js_error(cx, e))
                         }),
                     )?,
                 )?;
+
+                ctx.globals().set(
+                    "__javy_fetchio_request",
+                    Function::new(
+                        ctx.clone(),
+                        MutFn::new(move |cx, args| {
+                            let (cx, args) = hold_and_release!(cx, args);
+                            bless_fetch_request(hold!(cx.clone(), args))
+                                .map_err(|e| to_js_error(cx, e))
+                        }),
+                    )?,
+                )?;
+
+                // ctx.globals().set(
+                //     "BlessLLM",
+                //     Function::new(
+                //         ctx.clone(),
+                //         MutFn::new(move |cx, args| {
+                //             let (cx, args) = hold_and_release!(cx, args);
+                //             bless_llm_plugin(hold!(cx.clone(), args))
+                //                 .map_err(|e| to_js_error(cx, e))
+                //         }),
+                //     )?,
+                // )?;
+
+                ctx.eval::<(), _>(include_str!("crypto/crypto.js"))?;
+                ctx.eval::<(), _>(include_str!("fetch/fetch.js"))?;
+
                 Ok::<_, anyhow::Error>(())
             })
             .unwrap();
@@ -40,99 +77,4 @@ pub extern "C" fn initialize_runtime() {
         runtime
     })
     .unwrap();
-}
-
-fn bless_llm_plugin(args: Args<'_>) -> Result<Value<'_>> {
-    let (cx, args) = args.release();
-    if args.len() != 1 {
-        return Err(anyhow!("model name required"));
-    }
-
-    let model_name = args[0]
-        .as_string()
-        .ok_or_else(|| anyhow!("model name must be a string"))?
-        .to_string()
-        .map_err(|_| anyhow!("invalid UTF-8 in model name"))?;
-
-    // Create BlocklessLlm instance using SDK
-    let llm = Arc::new(Mutex::new(BlocklessLlm::new(&model_name).unwrap()));
-
-    // Convert to QuickJS object and expose SDK methods
-    let instance = Object::new(cx.clone())?;
-
-    let llm_ref = Arc::clone(&llm);
-    instance.set(
-        "setOptions",
-        Function::new(
-            cx.clone(),
-            MutFn::new(move |cx, args| {
-                let (cx, args) = hold_and_release!(cx, args);
-
-                let set_options = |args: Args<'_>| {
-                    let (_cx, args) = args.release();
-
-                    if args.len() != 1 {
-                        return Err(anyhow!("options must be an object"));
-                    }
-
-                    let opts_obj = args[0]
-                        .as_object()
-                        .ok_or_else(|| anyhow!("options must be an object"))?;
-
-                    let system_message = opts_obj.get::<_, String>("system_message")?;
-                    let options = LlmOptions {
-                        system_message,
-                        ..Default::default()
-                    };
-
-                    llm_ref
-                        .lock()
-                        .unwrap()
-                        .set_options(options)
-                        .map(|_| Value::new_undefined(cx.clone()))
-                        .map_err(|e| anyhow!("Set options failed: {:?}", e))
-                };
-
-                set_options(hold!(cx.clone(), args)).map_err(|e| to_js_error(cx, e))
-            }),
-        ),
-    )?;
-
-    let llm_ref = Arc::clone(&llm);
-    instance.set(
-        "chat",
-        Function::new(
-            cx.clone(),
-            MutFn::new(move |cx, args| {
-                let (cx, args) = hold_and_release!(cx, args);
-
-                let chat = |args: Args<'_>| {
-                    let (_cx, args) = args.release();
-
-                    if args.len() != 1 {
-                        return Err(anyhow!("prompt required"));
-                    }
-
-                    let prompt = args[0]
-                        .as_string()
-                        .ok_or_else(|| anyhow!("prompt required"))?
-                        .to_string()
-                        .map_err(|_| anyhow!("invalid UTF-8 in prompt"))?;
-                    llm_ref
-                        .lock()
-                        .unwrap()
-                        .chat_request(&prompt)
-                        .map(|res| {
-                            let js_string = JSString::from_str(cx.clone(), &res).unwrap();
-                            Value::from_string(js_string)
-                        })
-                        .map_err(|e| anyhow!("Chat request failed: {:?}", e))
-                };
-
-                chat(hold!(cx.clone(), args)).map_err(|e| to_js_error(cx, e))
-            }),
-        ),
-    )?;
-
-    Ok(Value::from_object(instance))
 }

--- a/src/llm/mod.rs
+++ b/src/llm/mod.rs
@@ -1,0 +1,103 @@
+use anyhow::{anyhow, Result};
+use blockless_sdk::{BlocklessLlm, LlmOptions};
+use javy_plugin_api::javy::{
+    hold, hold_and_release,
+    quickjs::{prelude::MutFn, Function, Object, String as JSString, Value},
+    to_js_error, Args,
+};
+use std::sync::{Arc, Mutex};
+
+pub fn bless_llm_plugin(args: Args<'_>) -> Result<Value<'_>> {
+    let (cx, args) = args.release();
+    if args.len() != 1 {
+        return Err(anyhow!("model name required"));
+    }
+
+    let model_name = args[0]
+        .as_string()
+        .ok_or_else(|| anyhow!("model name must be a string"))?
+        .to_string()
+        .map_err(|_| anyhow!("invalid UTF-8 in model name"))?;
+
+    // Create BlocklessLlm instance using SDK
+    let llm = Arc::new(Mutex::new(BlocklessLlm::new(&model_name).unwrap()));
+
+    // Convert to QuickJS object and expose SDK methods
+    let instance = Object::new(cx.clone())?;
+
+    let llm_ref = Arc::clone(&llm);
+    instance.set(
+        "setOptions",
+        Function::new(
+            cx.clone(),
+            MutFn::new(move |cx, args| {
+                let (cx, args) = hold_and_release!(cx, args);
+
+                let set_options = |args: Args<'_>| {
+                    let (_cx, args) = args.release();
+
+                    if args.len() != 1 {
+                        return Err(anyhow!("options must be an object"));
+                    }
+
+                    let opts_obj = args[0]
+                        .as_object()
+                        .ok_or_else(|| anyhow!("options must be an object"))?;
+
+                    let system_message = opts_obj.get::<_, String>("system_message")?;
+                    let options = LlmOptions {
+                        system_message,
+                        ..Default::default()
+                    };
+
+                    llm_ref
+                        .lock()
+                        .unwrap()
+                        .set_options(options)
+                        .map(|_| Value::new_undefined(cx.clone()))
+                        .map_err(|e| anyhow!("Set options failed: {:?}", e))
+                };
+
+                set_options(hold!(cx.clone(), args)).map_err(|e| to_js_error(cx, e))
+            }),
+        ),
+    )?;
+
+    let llm_ref = Arc::clone(&llm);
+    instance.set(
+        "chat",
+        Function::new(
+            cx.clone(),
+            MutFn::new(move |cx, args| {
+                let (cx, args) = hold_and_release!(cx, args);
+
+                let chat = |args: Args<'_>| {
+                    let (_cx, args) = args.release();
+
+                    if args.len() != 1 {
+                        return Err(anyhow!("prompt required"));
+                    }
+
+                    let prompt = args[0]
+                        .as_string()
+                        .ok_or_else(|| anyhow!("prompt required"))?
+                        .to_string()
+                        .map_err(|_| anyhow!("invalid UTF-8 in prompt"))?;
+                    llm_ref
+                        .lock()
+                        .unwrap()
+                        .chat_request(&prompt)
+                        .map(|res| {
+                            let js_string = JSString::from_str(cx.clone(), &res).unwrap();
+                            Value::from_string(js_string)
+                        })
+                        .map_err(|e| anyhow!("Chat request failed: {:?}", e))
+                };
+
+                chat(hold!(cx.clone(), args)).map_err(|e| to_js_error(cx, e))
+            }),
+        ),
+    )?;
+
+    Ok(Value::from_object(instance))
+}


### PR DESCRIPTION
Including 2 Javy plugins that were part of the previous bls-javy build.

- Fetch, proxies `fetch` with blockless_http native call
- Crypto, includes handy crypto library utilities that are not a part of the Javy

With the upgrade to the new Javy plugin structure, some important changes have been brought over:
- Enabling queues, allowing the usage of `Promise` and `async / await`
- Enabling `TextEncoder`
- Enabling stdin streams