### PR TITLE
LLM plugin MCP support

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -72,9 +72,9 @@ checksum = "8f68f53c83ab957f72c32642f3868eec03eb974d1fb82e453128456482613d36"
 
 [[package]]
 name = "blockless-sdk"
-version = "0.1.8"
+version = "0.1.10"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d392795cf239e8c57625262aaaa952924d631e0b37a76872897b5b557934de8d"
+checksum = "25f2739adfd37df55c6ad467ffd3e41d9d2ef1f30a1d5f9f2bb39bf4e736cd70"
 dependencies = [
  "json",
  "serde",
@@ -295,7 +295,7 @@ dependencies = [
 
 [[package]]
 name = "javy-bless-plugins"
-version = "0.2.1"
+version = "0.2.3"
 dependencies = [
  "anyhow",
  "blockless-sdk",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "javy-bless-plugins"
-version = "0.2.1"
+version = "0.2.3"
 authors = ["zees-dev"]
 description = "javy bless plugins"
 keywords = ["javy", "bless", "plugins"]
@@ -15,7 +15,7 @@ crate-type = ["cdylib"]
 
 [dependencies]
 anyhow = "1.0.95"
-blockless-sdk = { version = "0.1.8" }
+blockless-sdk = { version = "0.1.10" }
 javy-plugin-api = { version = "3.0.0", features = ["json"] }
 rand = "0.8.5"
 serde_json = "1.0.120"

--- a/README.md
+++ b/README.md
@@ -86,11 +86,11 @@ flowchart TD
 
 ```sh
 # build bless plugins
-cargo build --target=wasm32-wasip1 --release
+cargo build --target=wasm32-wasip1 --release --all-features
 
 # rebuild the plugin-wasm with javy runtime CLI
 javy init-plugin ./target/wasm32-wasip1/release/bless_plugins.wasm -o bless_plugins.wasm
 
-# compile javascript to wasm with javy runtime and plugin
+# compile javascript to wasm with javy QuickJS runtime and plugin - to be executed in a WASM runtime
 javy build -C plugin=bless_plugins.wasm ./examples/llm.js -o bless-llm.wasm
 ```

--- a/examples/llm-mcp.js
+++ b/examples/llm-mcp.js
@@ -1,0 +1,19 @@
+const models = JSON.stringify(MODELS, null, 2);
+console.log("Models", models);
+
+// Create instance
+const llm = BlessLLM(MODELS.MISTRAL_7B.DEFAULT);
+
+// Set options
+llm.setOptions({
+  tools_sse_urls: [
+    "http://localhost:3001/sse",
+  ],
+});
+
+// Get options
+const options = llm.getOptions();
+console.log("Options", JSON.stringify(options, null, 2));
+
+// Chat
+console.log(llm.chat("Add the following numbers: 1215, 2213"));


### PR DESCRIPTION
## Description
This pull request introduces several updates to the `javy-bless-plugins` project, including dependency upgrades, enhancements to the plugin's configuration capabilities, and improvements to documentation and examples.
The most important changes focus on extending the flexibility of the plugin's options and updating dependencies to newer versions.

### Dependency Updates:
* Updated `blockless-sdk` dependency from version `0.1.8` to `0.1.10` in `Cargo.toml` to incorporate the latest features and fixes.
* Updated the `version` of the `javy-bless-plugins` package from `0.2.1` to `0.2.3` in `Cargo.toml`.

### Plugin Enhancements:
* Replaced `SupportedModels` with `Models` in `src/llm/mod.rs` to align with the updated `blockless-sdk` API. This change includes improved error handling for invalid model names. [[1]](diffhunk://#diff-6033067bc6dcd6bca132f28636debff11acca4c1f9baf6c2882067cf5fa940efL2-R2) [[2]](diffhunk://#diff-6033067bc6dcd6bca132f28636debff11acca4c1f9baf6c2882067cf5fa940efL75-R76)
* Extended the `LlmOptions` struct to support additional configuration options (`tools_sse_urls`, `temperature`, `top_p`) and updated the logic to handle optional values in `src/llm/mod.rs`.
* Enhanced the plugin's ability to return structured options, including handling optional fields (`system_message`, `tools_sse_urls`) and properly formatting them as JavaScript objects in `src/llm/mod.rs`.

### Documentation and Examples:
* Updated the build command in `README.md` to include the `--all-features` flag for building with all features enabled. Clarified the description of the `javy build` command to specify the use of the QuickJS runtime.
* Added a new example script, `examples/llm-mcp.js`, demonstrating how to create an LLM instance, set options, retrieve options, and perform a chat operation.